### PR TITLE
Added 'test_delete_03' test.

### DIFF
--- a/iaed-p2/tests/test_delete_03.in
+++ b/iaed-p2/tests/test_delete_03.in
@@ -1,0 +1,9 @@
+set usr Utilizador
+set home/documents Docs
+set home/pictures My compromising photos :o
+set temp Temporary Files
+delete
+set temp Temporary Files
+set boot Boot Files
+list
+quit

--- a/iaed-p2/tests/test_delete_03.out
+++ b/iaed-p2/tests/test_delete_03.out
@@ -1,0 +1,2 @@
+boot
+temp


### PR DESCRIPTION
Added a more comprehensive test to the `delete` command when it is invoked without arguments. This test allows users to better understand the functionality of this command, and allows an easier testing to memory leaks and errors than **test_delete_01** and **test_delete_02**, given the superior complexity of both these tests.