### PR TITLE
Update wrongly updated test (FP 2021 P1)

### DIFF
--- a/fp/2021-2022/fp-p1/proj_tester.py
+++ b/fp/2021-2022/fp-p1/proj_tester.py
@@ -351,7 +351,7 @@ class TestVerificacaoDados3(unittest.TestCase):
         self.assertFalse(target.validar_cifra("aaa-b-c-d-e-f", "[bcdef]"))
         
     def test_validar_cifra_5(self):
-        self.assertTrue(target.validar_cifra("a-b-c-d-e-f", "[bcdef]"))
+        self.assertTrue(target.validar_cifra("xx-yy-aa-bb-cd-cd-ee", "[abcde]"))
 
     def test_filtrar_bdb_1(self):
         with self.assertRaises(ValueError, msg="ValueError not raised") as ctx:


### PR DESCRIPTION
Alphabetical order only in the elements inside "checksum", if all elements, same occurence, disregard alphabetical order.
a-b-c-d-e-f-g-h, [bcdef], [cdefh], ... correct "checksum", because all inside in alphabetical order.