### PR TITLE
Fixed test_corrigir_doc_044 (FP 2021 P1)

### DIFF
--- a/fp/2021-2022/fp-p1/proj_tester.py
+++ b/fp/2021-2022/fp-p1/proj_tester.py
@@ -119,8 +119,8 @@ class TestDocumentacao1(unittest.TestCase):
         self.assertEqual("Fundamentos da Programacao e Programacao com objetos", target.corrigir_doc(doc))
         
     def test_corrigir_doc_044(self):
-        doc = "Fundamentos da Programacao e Programacao com objetos"
-        self.assertEqual("Fundamentos da Programacao e Programacao com objetos", target.corrigir_doc(doc))
+        doc = "Fundamentos da Programacao e programacao com objetos"
+        self.assertEqual("Fundamentos da Programacao e com objetos", target.corrigir_doc(doc))
         
     def test_corrigir_doc_045(self):
         doc = "Programacao com objetos e bojetos"


### PR DESCRIPTION
Input was supposed to be "Fundamentos da Programacao e programacao com objetos" with output expected being "Fundamentos da Programacao e com objetos".
However, test_corrigir_doc_044 was a copy of test_corrigir_doc043 and didn't follow what was expected.