### PR TITLE
Add support for Taguspark's project by using reflection to find WarehouseManager (PO 2021)

### DIFF
--- a/po/2021-2022/po-p1/tests/ggctests/DateTest.java
+++ b/po/2021-2022/po-p1/tests/ggctests/DateTest.java
@@ -1,6 +1,5 @@
 package ggctests;
 
-import ggc.app.exceptions.InvalidDateException;
 import ggctests.utils.PoUILibTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,7 +48,7 @@ public class DateTest extends PoUILibTest {
 
         this.runApp();
 
-        assertThrownCommandException(InvalidDateException.class, "Data inválida: " + value);
+        assertThrownCommandException("InvalidDateException", "Data inválida: " + value);
         assertNoMoreExceptions();
         assertEquals("", this.interaction.getResult());
     }

--- a/po/2021-2022/po-p1/tests/ggctests/LoadAndSaveTest.java
+++ b/po/2021-2022/po-p1/tests/ggctests/LoadAndSaveTest.java
@@ -1,6 +1,5 @@
 package ggctests;
 
-import ggc.WarehouseManager;
 import ggc.app.exceptions.FileOpenFailedException;
 import ggctests.utils.PoUILibTest;
 import org.junit.jupiter.api.AfterAll;
@@ -42,7 +41,7 @@ public class LoadAndSaveTest extends PoUILibTest {
         }
 
         protected void resetWarehouseManager() {
-            this.warehouseManager = new WarehouseManager();
+            this.warehouseManager = newWarehouseManager();
         }
     }
 

--- a/po/2021-2022/po-p1/tests/ggctests/LoadAndSaveTest.java
+++ b/po/2021-2022/po-p1/tests/ggctests/LoadAndSaveTest.java
@@ -1,6 +1,5 @@
 package ggctests;
 
-import ggc.app.exceptions.FileOpenFailedException;
 import ggctests.utils.PoUILibTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -198,7 +197,7 @@ public class LoadAndSaveTest extends PoUILibTest {
 
         this.runApp();
 
-        assertThrownCommandException(FileOpenFailedException.class, "Problema ao abrir 'file_that_does_not_exist.dat'.");
+        assertThrownCommandException("FileOpenFailedException", "Problema ao abrir 'file_that_does_not_exist.dat'.");
         assertNoMoreExceptions();
         assertEquals("", this.interaction.getResult());
     }

--- a/po/2021-2022/po-p1/tests/ggctests/RegisterPartnerTest.java
+++ b/po/2021-2022/po-p1/tests/ggctests/RegisterPartnerTest.java
@@ -1,7 +1,5 @@
 package ggctests;
 
-import ggc.app.exceptions.DuplicatePartnerKeyException;
-import ggc.app.exceptions.UnknownPartnerKeyException;
 import ggctests.utils.PoUILibTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -64,7 +62,7 @@ public class RegisterPartnerTest {
 
             this.runApp();
 
-            assertThrownCommandException(UnknownPartnerKeyException.class, "O parceiro '" + key + "' não existe.");
+            assertThrownCommandException("UnknownPartnerKeyException", "O parceiro '" + key + "' não existe.");
             assertNoMoreExceptions();
             assertEquals("", this.interaction.getResult());
         }
@@ -139,8 +137,8 @@ public class RegisterPartnerTest {
 
             this.runApp();
 
-            assertThrownCommandException(DuplicatePartnerKeyException.class, "O parceiro 'YYYYYYYY' já existe.");
-            assertThrownCommandException(DuplicatePartnerKeyException.class, "O parceiro 'CCCCCCCCP1' já existe.");
+            assertThrownCommandException("DuplicatePartnerKeyException", "O parceiro 'YYYYYYYY' já existe.");
+            assertThrownCommandException("DuplicatePartnerKeyException", "O parceiro 'CCCCCCCCP1' já existe.");
             assertNoMoreExceptions();
             assertEquals("""
                             AAAAS1|Toshiba|Tokyo, Japan|NORMAL|0|0|0|0
@@ -171,10 +169,10 @@ public class RegisterPartnerTest {
 
             this.runApp();
 
-            assertThrownCommandException(DuplicatePartnerKeyException.class, "O parceiro 'aaAAS1' já existe.");
-            assertThrownCommandException(DuplicatePartnerKeyException.class, "O parceiro 'ddddddp3' já existe.");
-            assertThrownCommandException(DuplicatePartnerKeyException.class, "O parceiro 'WEWE' já existe.");
-            assertThrownCommandException(DuplicatePartnerKeyException.class, "O parceiro 'WewE' já existe.");
+            assertThrownCommandException("DuplicatePartnerKeyException", "O parceiro 'aaAAS1' já existe.");
+            assertThrownCommandException("DuplicatePartnerKeyException", "O parceiro 'ddddddp3' já existe.");
+            assertThrownCommandException("DuplicatePartnerKeyException", "O parceiro 'WEWE' já existe.");
+            assertThrownCommandException("DuplicatePartnerKeyException", "O parceiro 'WewE' já existe.");
             assertNoMoreExceptions();
             assertEquals("""
                             AAAAS1|Toshiba|Tokyo, Japan|NORMAL|0|0|0|0

--- a/po/2021-2022/po-p1/tests/ggctests/utils/PoUILibTest.java
+++ b/po/2021-2022/po-p1/tests/ggctests/utils/PoUILibTest.java
@@ -1,7 +1,5 @@
 package ggctests.utils;
 
-import ggc.WarehouseManager;
-import ggc.exceptions.ImportFileException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +8,9 @@ import pt.tecnico.uilib.Dialog;
 import pt.tecnico.uilib.menus.CommandException;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -20,10 +21,47 @@ import static org.junit.jupiter.api.Assertions.fail;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class PoUILibTest {
 
+    private static Class<?> warehouseManagerClass;
+    private static Constructor<?> warehouseManagerConstructor;
+    private static Method warehouseManagerImportFileMethod;
+    private static Constructor<ggc.app.main.Menu> mainMenuConstructor;
+
+    static {
+      try {
+        warehouseManagerClass = Class.forName("ggc.WarehouseManager");
+      } catch (ClassNotFoundException e) {
+        try {
+          warehouseManagerClass = Class.forName("ggc.core.WarehouseManager");
+        } catch (ClassNotFoundException ex) {
+          fail("Could not find a WarehouseManager class to hook into. Searched at ggc.WarehouseManager and ggc.core.WarehouseManager", ex);
+        }
+      }
+      try {
+        warehouseManagerConstructor = warehouseManagerClass.getConstructor();
+      } catch (NoSuchMethodException e) {
+        fail("Could not find the default constructor for WarehouseManager. Make sure it has a public constructor without arguments", e);
+      }
+
+      try {
+        warehouseManagerImportFileMethod = warehouseManagerClass.getMethod("importFile", String.class);
+      } catch (NoSuchMethodException e) {
+        fail("Could not find a public importFile(String) method on WarehouseManager", e);
+      }
+
+      try {
+        mainMenuConstructor = ggc.app.main.Menu.class.getConstructor(warehouseManagerClass);
+      } catch (NoSuchMethodException e) {
+        fail("Could not find a constructor on main menu that takes a WarehouseManager", e);
+      }
+
+    }
+
     private boolean resetWarehouseManagerBeforeEach = false;
     private Dialog dialog;
     protected TestsInteraction interaction;
-    protected WarehouseManager warehouseManager;
+    /* Since Alameda and Tagus are using different packages for this, we're going to
+       have to use reflection to correctly use this */
+    protected Object warehouseManager;
 
     public PoUILibTest() {
     }
@@ -34,6 +72,15 @@ public abstract class PoUILibTest {
 
     protected abstract void setupWarehouseManager();
 
+    public Object newWarehouseManager() {
+      try {
+        return warehouseManagerConstructor.newInstance();
+      } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+        fail("Failed to instantiate a new WarehouseManager with a public empty constructor", e);
+      }
+      return null;
+    }
+
     @BeforeAll
     public void setupDialogInstance() {
         this.interaction = new TestsInteraction();
@@ -41,7 +88,7 @@ public abstract class PoUILibTest {
         Dialog.UI = this.dialog;
 
         if (!resetWarehouseManagerBeforeEach) {
-            this.warehouseManager = new WarehouseManager();
+            this.warehouseManager = newWarehouseManager();
 
             setupWarehouseManager();
         }
@@ -52,14 +99,18 @@ public abstract class PoUILibTest {
         this.interaction.reset();
 
         if (resetWarehouseManagerBeforeEach) {
-            this.warehouseManager = new WarehouseManager();
+            this.warehouseManager = newWarehouseManager();
 
             setupWarehouseManager();
         }
     }
 
     protected void runApp() {
-        new ggc.app.main.Menu(this.warehouseManager).open();
+      try {
+          mainMenuConstructor.newInstance(this.warehouseManager).open();
+      } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+          fail("Failed to instantiate the main menu with the WarehouseManager", e);
+      }
     }
 
     @AfterAll
@@ -85,8 +136,10 @@ public abstract class PoUILibTest {
 
     protected void loadFromInputFile(String fileName) {
         try {
-            this.warehouseManager.importFile("tests/resources/" + fileName);
-        } catch (ImportFileException e) {
+            warehouseManagerImportFileMethod.invoke(this.warehouseManager, "tests/resources/" + fileName);
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            fail("Failed to invoke importFile method via reflection", e);
+        } catch (Exception e) { /* have to use a generic exception because of reflection */
             fail("Could not import from file " + fileName);
         }
     }


### PR DESCRIPTION
Taguspark (LEIC-T and LETI) have the `WarehouseManager` class located at `ggc.core.WarehouseManager` instead of `ggc.WarehouseManager` like Alameda, so this PR uses reflection to try both packages instead of hardcoding the class with imports.