### PR TITLE
[FP 2022/2023 P1] General Reformatting and fixed wrong ValueError message

### DIFF
--- a/fp/2022-2023/fp-p1/proj_tester.py
+++ b/fp/2022-2023/fp-p1/proj_tester.py
@@ -22,7 +22,7 @@ target = importlib.util.module_from_spec(target_spec)
 exec(open(file_name, encoding="utf-8").read(), target.__dict__)
 
 
-class TestPublicJustificarTextos:
+class TestJustificarTextos:
 
     # Limpa_texto
     # Forma geral
@@ -117,32 +117,32 @@ class TestPublicJustificarTextos:
 
     # levantar erro se primeiro argumento não é uma lista não vazia, ou o segundo não é um número inteiro positivo
     # ou existe uma palavra maior que o tamanho pretendido
-    def test_justifica_texto_raise_errors1(self):
+    def test_justifica_texto_error1(self):
         with pytest.raises(ValueError, match='justifica_texto: argumentos invalidos'):
             target.justifica_texto('', 60)
 
-    def test_justifica_texto_raise_errors2(self):
+    def test_justifica_texto_error2(self):
         with pytest.raises(ValueError, match='justifica_texto: argumentos invalidos'):
             target.justifica_texto('Fundamentos', "Banana")
 
-    def test_justifica_texto_raise_errors3(self):
+    def test_justifica_texto_error3(self):
         with pytest.raises(ValueError, match='justifica_texto: argumentos invalidos'):
             target.justifica_texto(89, 60)
 
-    def test_justifica_texto_raise_errors4(self):
+    def test_justifica_texto_error4(self):
         with pytest.raises(ValueError, match='justifica_texto: argumentos invalidos'):
             target.justifica_texto('Texto', -10)
 
-    def test_justifica_texto_raise_errors5(self):
+    def test_justifica_texto_error5(self):
         with pytest.raises(ValueError, match='justifica_texto: argumentos invalidos'):
             target.justifica_texto('Otorrinolaringologista', 10)
 
-    def test_justifica_texto_raise_error6(self):
+    def test_justifica_texto_error6(self):
         with pytest.raises(ValueError, match='justifica_texto: argumentos invalidos'):
             target.justifica_texto('123456 123', 4)
 
 
-class TestPublicMetodoHondt:
+class TestMetodoHondt:
 
     def test_calcula_quocientes1(self):
 
@@ -203,12 +203,12 @@ class TestPublicMetodoHondt:
 
         assert ref == target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors1(self):
+    def test_obtem_resultado_eleicoes_error1(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors2(self):
+    def test_obtem_resultado_eleicoes_error2(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7,
@@ -217,12 +217,12 @@ class TestPublicMetodoHondt:
                             'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}}, }
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors3(self):
+    def test_obtem_resultado_eleicoes_error3(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = 13
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors4(self):
+    def test_obtem_resultado_eleicoes_error4(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7,
@@ -231,7 +231,7 @@ class TestPublicMetodoHondt:
                             'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}}, }
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors5(self):
+    def test_obtem_resultado_eleicoes_error5(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7,
@@ -240,12 +240,12 @@ class TestPublicMetodoHondt:
                             'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}}, }
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors6(self):
+    def test_obtem_resultado_eleicoes_error6(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {'Endor': 15}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors7(self):
+    def test_obtem_resultado_eleicoes_error7(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': "não é número inteiro",
@@ -254,7 +254,7 @@ class TestPublicMetodoHondt:
                             'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}}, }
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors8(self):
+    def test_obtem_resultado_eleicoes_error8(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7},
@@ -262,7 +262,7 @@ class TestPublicMetodoHondt:
                             'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}}, }
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors9(self):
+    def test_obtem_resultado_eleicoes_error9(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
@@ -285,15 +285,15 @@ class TestPublicMetodoHondt:
     #       -> Verificar se a key correspondente aos numeros de votos é do tipo
     #           correto STR                                                                (23)
 
-    def test_obtem_resultado_eleicoes_raise_errors10(self):
+    def test_obtem_resultado_eleicoes_error10(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             target.obtem_resultado_eleicoes('deez nuts')
 
-    def test_obtem_resultado_eleicoes_raise_errors11(self):
+    def test_obtem_resultado_eleicoes_error11(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             target.obtem_resultado_eleicoes({})
 
-    def test_obtem_resultado_eleicoes_raise_errors12(self):
+    def test_obtem_resultado_eleicoes_error12(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7,
@@ -304,7 +304,7 @@ class TestPublicMetodoHondt:
                              'votos': {'A': 3000, 'B': 1900}}}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors13(self):
+    def test_obtem_resultado_eleicoes_error13(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7,
@@ -315,7 +315,7 @@ class TestPublicMetodoHondt:
                              'xxx': {'A': 3000, 'B': 1900}}}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors14(self):
+    def test_obtem_resultado_eleicoes_error14(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7,
@@ -326,7 +326,7 @@ class TestPublicMetodoHondt:
                              'votos': {'A': 3000, 'B': 1900}}}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors15(self):
+    def test_obtem_resultado_eleicoes_error15(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7,
@@ -337,7 +337,7 @@ class TestPublicMetodoHondt:
                              'votos': {'A': 3000, 'B': 1900}}}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors16(self):
+    def test_obtem_resultado_eleicoes_error16(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7,
@@ -348,7 +348,7 @@ class TestPublicMetodoHondt:
                              'votos': {'A': 3000, 'B': 1900}}}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors17(self):
+    def test_obtem_resultado_eleicoes_error17(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7,
@@ -359,7 +359,7 @@ class TestPublicMetodoHondt:
                              'votos': {'A': 3000, 'B': 1900}}}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors18(self):
+    def test_obtem_resultado_eleicoes_error18(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7,
@@ -370,7 +370,7 @@ class TestPublicMetodoHondt:
                              'votos': {'A': -69, 'B': 1900}}}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors19(self):
+    def test_obtem_resultado_eleicoes_error19(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 0,
@@ -381,7 +381,7 @@ class TestPublicMetodoHondt:
                              'votos': {'A': 3000, 'B': 1900}}}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors20(self):
+    def test_obtem_resultado_eleicoes_error20(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7,
@@ -392,7 +392,7 @@ class TestPublicMetodoHondt:
                              'votos': {'A': 3000, 'B': 1900}}}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors21(self):
+    def test_obtem_resultado_eleicoes_error21(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7},
@@ -402,7 +402,7 @@ class TestPublicMetodoHondt:
                              'votos': {'A': 3000, 'B': 1900}}}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors22(self):
+    def test_obtem_resultado_eleicoes_error22(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
@@ -412,7 +412,7 @@ class TestPublicMetodoHondt:
                              'votos': {'A': 3000, 'B': 1900}}}
             target.obtem_resultado_eleicoes(info)
 
-    def test_obtem_resultado_eleicoes_raise_errors23(self):
+    def test_obtem_resultado_eleicoes_error23(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
                 'Endor':   {'deputados': 7,
@@ -470,7 +470,7 @@ class TestPublicMetodoHondt:
 
 
 
-class TestPublicSistemasLineares:
+class TestSistemasLineares:
 
     def test_produto_interno1(self):
         assert target.produto_interno(

--- a/fp/2022-2023/fp-p1/proj_tester.py
+++ b/fp/2022-2023/fp-p1/proj_tester.py
@@ -272,18 +272,18 @@ class TestPublicMetodoHondt:
 
     # Verificar que o programa gera Value Error no caso de argumentos não válidos
     # LISTA DE TESTES:
-    #       -> Verificar se o argumento é do tipo DICT                                     (3)
-    #       -> Verificar se o argumento está vazio                                         (4)
-    #       -> Verificar se o dicionario dos votos está vazio                              (5)
-    #       -> Verificar os nomes das keys (VOTOS, DEPUTADOS)                              (6, 7)
-    #       -> Verificar se o valor de (DEPUTADOS, VOTOS) são do tipo correto (INT, DICT)  (8, 9)
-    #       -> Verificar se o valor de votos de cada partido é do tipo correto INT         (10)
+    #       -> Verificar se o argumento é do tipo DICT                                     (10)
+    #       -> Verificar se o argumento está vazio                                         (11)
+    #       -> Verificar se o dicionario dos votos está vazio                              (12)
+    #       -> Verificar os nomes das keys (VOTOS, DEPUTADOS)                              (13, 14)
+    #       -> Verificar se o valor de (DEPUTADOS, VOTOS) são do tipo correto (INT, DICT)  (15, 16)
+    #       -> Verificar se o valor de votos de cada partido é do tipo correto INT         (17)
     #       -> Verificar se o valor de votos for negativo e valor de deputados for 0
-    #          ou inferior                                                                 (11, 12)
-    #       -> Verificar se existir um circulo eleitoral com 0 votos totais                (13)
-    #       -> Verificar se falta a key VOTOS ou a key DEPUTADOS                           (14, 15)
+    #          ou inferior                                                                 (18, 19)
+    #       -> Verificar se existir um circulo eleitoral com 0 votos totais                (20)
+    #       -> Verificar se falta a key VOTOS ou a key DEPUTADOS                           (21, 22)
     #       -> Verificar se a key correspondente aos numeros de votos é do tipo
-    #           correto STR                                                                   (16)
+    #           correto STR                                                                (23)
 
     def test_obtem_resultado_eleicoes_raise_errors10(self):
         with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
@@ -427,7 +427,7 @@ class TestPublicMetodoHondt:
     # os dicionarios de entrada das funções não devem ser alterados #
     #################################################################
 
-    def test_calcula_quocientes_alteracao_diconarios(self):
+    def test_calcula_quocientes_alteracao_dicionarios(self):
         dicionario = {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}
         copia_dicionario = copy.deepcopy(dicionario)
 

--- a/fp/2022-2023/fp-p1/proj_tester.py
+++ b/fp/2022-2023/fp-p1/proj_tester.py
@@ -21,40 +21,59 @@ target_spec = importlib.util.spec_from_loader("target", loader=None)
 target = importlib.util.module_from_spec(target_spec)
 exec(open(file_name, encoding="utf-8").read(), target.__dict__)
 
+
 class TestPublicJustificarTextos:
-    
+
     # Limpa_texto
     # Forma geral
     def test_limpa_texto1(self):
-        assert ('Fundamentos da Programacao' == target.limpa_texto('  Fundamentos\n\tda      Programacao\n'))
+        assert ('Fundamentos da Programacao' == target.limpa_texto(
+            '  Fundamentos\n\tda      Programacao\n'))
+
     # Com espaços no final e \v, \f e \r
     def test_limpa_texto2(self):
-        assert ('Fundamentos da Programacao' == target.limpa_texto('  Fundamentos\v\fda      Programacao\r         '))
-    
+        assert ('Fundamentos da Programacao' == target.limpa_texto(
+            '  Fundamentos\v\fda      Programacao\r         '))
+
     def test_limpa_texto3(self):
-        assert ('A B C D E F G' == target.limpa_texto('\t\n\v\f\r A\t B\nC\vD \fE\rF G\r \f\n \v'))
+        assert ('A B C D E F G' == target.limpa_texto(
+            '\t\n\v\f\r A\t B\nC\vD \fE\rF G\r \f\n \v'))
+
+    # Testar com caracteres brancos no meio da frase
+    def test_limpa_texto4(self):
+        assert ('Fundamentos da Program acao' == target.limpa_texto(
+            '  Fundamentos\v\fda      Program\nacao\r         '))
+
+    # Verificar que sobrevive uma string vazia
+    def test_limpa_texto5(self):
+        assert ('' == target.limpa_texto(''))
 
     # Corta Texto
     # Forma geral
     def test_corta_texto1(self):
-        assert ('Fundamentos da', 'Programacao') == target.corta_texto('Fundamentos da Programacao', 15)
+        assert ('Fundamentos da', 'Programacao') == target.corta_texto(
+            'Fundamentos da Programacao', 15)
 
     # 'Fundamentos da' -> tem 14 letras
     # Verifica se o utilizador conta com o espaço quando está a inserir
     def test_corta_texto2(self):
-        assert ('Fundamentos', 'da Programacao') == target.corta_texto('Fundamentos da Programacao', 13)
+        assert ('Fundamentos', 'da Programacao') == target.corta_texto(
+            'Fundamentos da Programacao', 13)
 
     # Verifica se o utilizador consegue inserir espaços de forma uniforme
     def test_insere_espacos1(self):
-        assert 'Fundamentos  da Programacao!!!' == target.insere_espacos('Fundamentos da Programacao!!!', 30)
+        assert 'Fundamentos  da Programacao!!!' == target.insere_espacos(
+            'Fundamentos da Programacao!!!', 30)
 
     # Verifica se o utilizador insere mais do que 2 espaços seguidos se for preciso
     def test_insere_espacos2(self):
-        assert 'Fundamentos       da      Programacao!!!' == target.insere_espacos('Fundamentos da Programacao!!!', 40)
+        assert 'Fundamentos       da      Programacao!!!' == target.insere_espacos(
+            'Fundamentos da Programacao!!!', 40)
 
     # Verifica se o utilizador consegue fazer com textos maiores que 3 palavras
     def test_insere_espacos3(self):
-        assert 'Lorem  Ipsum  is  simply  dummy  text  of  the  printing and typesetting industry.' == target.insere_espacos('Lorem Ipsum is simply dummy text of the printing and typesetting industry.', 82)
+        assert 'Lorem  Ipsum  is  simply  dummy  text  of  the  printing and typesetting industry.' == target.insere_espacos(
+            'Lorem Ipsum is simply dummy text of the printing and typesetting industry.', 82)
 
     # Verifica se o utilizador insere espaços quando só existem duas palavras
     def test_insere_espacos4(self):
@@ -62,7 +81,8 @@ class TestPublicJustificarTextos:
 
     # Verifica se o utilizador insere espaços uniformes, caso seja preciso
     def test_insere_espacos5(self):
-        assert 'Lorem  Ipsum  is  simply  dummy' == target.insere_espacos('Lorem Ipsum is simply dummy', 31)
+        assert 'Lorem  Ipsum  is  simply  dummy' == target.insere_espacos(
+            'Lorem Ipsum is simply dummy', 31)
 
     # Verifica se o utilizador insere espaços só para a frente da palavra, mesmo que só seja uma letra
     def test_insere_espacos6(self):
@@ -75,20 +95,20 @@ class TestPublicJustificarTextos:
     # Verifica se o utilizador formata o texto pedido no pdf
     def test_justifica_texto1(self):
         cad = ('Computers are incredibly  \n\tfast,     \n\t\taccurate'
-            ' \n\t\t\tand  stupid.   \n    Human beings are incredibly  slow  '
-            'inaccurate, and brilliant. \n     Together  they  are powerful   '
-            'beyond imagination.')
+               ' \n\t\t\tand  stupid.   \n    Human beings are incredibly  slow  '
+               'inaccurate, and brilliant. \n     Together  they  are powerful   '
+               'beyond imagination.')
 
         ref = ('Computers  are  incredibly  fast, accurate and stupid. Human',
-            'beings   are  incredibly  slow  inaccurate,  and  brilliant.',
-            'Together they are powerful beyond imagination.              ')
+               'beings   are  incredibly  slow  inaccurate,  and  brilliant.',
+               'Together they are powerful beyond imagination.              ')
         assert ref == target.justifica_texto(cad, 60)
 
     def test_justifica_texto2(self):
         cad = ('Computers are incredibly  \n\tfast,     \n\t\taccurate')
         ref = ('Computers are incredibly fast, accurate           ',)
         assert ref == target.justifica_texto(cad, 50)
-    
+
     # Verifica se o utilizador formata cadeias com segmentos internos de comprimento igual à largura de coluna
     def test_justifica_texto3(self):
         cad = ('123456 123')
@@ -116,135 +136,303 @@ class TestPublicJustificarTextos:
     def test_justifica_texto_raise_errors5(self):
         with pytest.raises(ValueError, match='justifica_texto: argumentos invalidos'):
             target.justifica_texto('Otorrinolaringologista', 10)
-            
+
     def test_justifica_texto_raise_error6(self):
         with pytest.raises(ValueError, match='justifica_texto: argumentos invalidos'):
             target.justifica_texto('123456 123', 4)
-
 
 
 class TestPublicMetodoHondt:
 
     def test_calcula_quocientes1(self):
 
-        ref =  {'A': [12000.0, 6000.0, 4000.0, 3000.0, 2400.0, 2000.0, 12000/7],
-                    'B': [7500.0, 3750.0, 2500.0, 1875.0, 1500.0, 1250.0, 7500/7],
-                    'C': [5250.0, 2625.0, 1750.0, 1312.5, 1050.0, 875.0, 750.0],
-                    'D': [3000.0, 1500.0, 1000.0, 750.0, 600.0, 500.0, 3000/7]}
+        ref = {'A': [12000.0, 6000.0, 4000.0, 3000.0, 2400.0, 2000.0, 12000/7],
+               'B': [7500.0, 3750.0, 2500.0, 1875.0, 1500.0, 1250.0, 7500/7],
+               'C': [5250.0, 2625.0, 1750.0, 1312.5, 1050.0, 875.0, 750.0],
+               'D': [3000.0, 1500.0, 1000.0, 750.0, 600.0, 500.0, 3000/7]}
 
-        hyp = target.calcula_quocientes({'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}, 7)
-        
+        hyp = target.calcula_quocientes(
+            {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}, 7)
+
         assert ref == hyp
-
 
     def test_atribui_mandatos1(self):
         ref = ['A', 'B', 'A', 'C', 'A', 'B', 'D']
-        assert ref == target.atribui_mandatos({'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}, 7)
+        assert ref == target.atribui_mandatos(
+            {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}, 7)
 
     def test_atribui_mandatos2(self):
         ref = ['A', 'B', 'A', 'C', 'A', 'B', 'D']
-        assert ref == target.atribui_mandatos({'D': 3000, 'B': 7500, 'C': 5250, 'A': 12000}, 7)
-
+        assert ref == target.atribui_mandatos(
+            {'D': 3000, 'B': 7500, 'C': 5250, 'A': 12000}, 7)
 
     def test_obtem_partidos1(self):
         info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
+            'Endor':   {'deputados': 7,
+                        'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+            'Hoth':    {'deputados': 6,
+                        'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+            'Tatooine': {'deputados': 3,
+                         'votos': {'A': 3000, 'B': 1900}}}
 
         ref = ['A', 'B', 'C', 'D', 'E']
-        
-        assert ref == target.obtem_partidos(info)
 
+        assert ref == target.obtem_partidos(info)
 
     def test_obtem_resultado_eleicoes1(self):
         info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
-        ref = [('A', 7, 24000), ('B', 6, 20900), ('C', 1, 5250), ('E', 1, 5000), ('D', 1, 4500)]
-        
+            'Endor':   {'deputados': 7,
+                        'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+            'Hoth':    {'deputados': 6,
+                        'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+            'Tatooine': {'deputados': 3,
+                         'votos': {'A': 3000, 'B': 1900}}}
+        ref = [('A', 7, 24000), ('B', 6, 20900),
+               ('C', 1, 5250), ('E', 1, 5000), ('D', 1, 4500)]
+
+        assert ref == target.obtem_resultado_eleicoes(info)
+
+    def test_obtem_resultado_eleicoes2(self):
+        info = {
+            'Endor':   {'deputados': 12,
+                        'votos': {'A': 117542, 'B': 79123, 'C': 47887, 'D': 28991}},
+            'Hoth':    {'deputados': 4,
+                        'votos': {'B': 47800, 'A': 56000, 'E': 12877, 'D': 28000}}}
+        ref = [('A', 7, 173542), ('B', 5, 126923),
+               ('D', 2, 56991), ('C', 2, 47887), ('E', 0, 12877)]
+
         assert ref == target.obtem_resultado_eleicoes(info)
 
     def test_obtem_resultado_eleicoes_raise_errors1(self):
-        with pytest.raises(ValueError, match='obtem resultado eleicoes: argumento invalido'):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {}
             target.obtem_resultado_eleicoes(info)
 
     def test_obtem_resultado_eleicoes_raise_errors2(self):
-        with pytest.raises(ValueError, match='obtem resultado eleicoes: argumento invalido'):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 0, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},}
+                'Endor':   {'deputados': 7,
+                            'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 0,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}}, }
             target.obtem_resultado_eleicoes(info)
 
     def test_obtem_resultado_eleicoes_raise_errors3(self):
-        with pytest.raises(ValueError, match='obtem resultado eleicoes: argumento invalido'):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = 13
             target.obtem_resultado_eleicoes(info)
 
     def test_obtem_resultado_eleicoes_raise_errors4(self):
-        with pytest.raises(ValueError, match='obtem resultado eleicoes: argumento invalido'):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':0, 'B':0, 'C':0, 'D':0}},
-            'Hoth':    {'deputados': 3, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},}
+                'Endor':   {'deputados': 7,
+                            'votos': {'A': 0, 'B': 0, 'C': 0, 'D': 0}},
+                'Hoth':    {'deputados': 3,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}}, }
             target.obtem_resultado_eleicoes(info)
 
     def test_obtem_resultado_eleicoes_raise_errors5(self):
-        with pytest.raises(ValueError, match='obtem resultado eleicoes: argumento invalido'):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {}},
-            'Hoth':    {'deputados': 3, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},}
+                'Endor':   {'deputados': 7,
+                            'votos': {}},
+                'Hoth':    {'deputados': 3,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}}, }
             target.obtem_resultado_eleicoes(info)
 
     def test_obtem_resultado_eleicoes_raise_errors6(self):
-        with pytest.raises(ValueError, match='obtem resultado eleicoes: argumento invalido'):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {'Endor': 15}
             target.obtem_resultado_eleicoes(info)
 
     def test_obtem_resultado_eleicoes_raise_errors7(self):
-        with pytest.raises(ValueError, match='obtem resultado eleicoes: argumento invalido'):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
-            'Endor':   {'deputados': "não é número inteiro", 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 3, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},}
+                'Endor':   {'deputados': "não é número inteiro",
+                            'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 3,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}}, }
             target.obtem_resultado_eleicoes(info)
 
     def test_obtem_resultado_eleicoes_raise_errors8(self):
-        with pytest.raises(ValueError, match='obtem resultado eleicoes: argumento invalido'):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
-            'Endor':   {'deputados': 7},
-            'Hoth':    {'deputados': 3, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},}
+                'Endor':   {'deputados': 7},
+                'Hoth':    {'deputados': 3,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}}, }
             target.obtem_resultado_eleicoes(info)
 
     def test_obtem_resultado_eleicoes_raise_errors9(self):
-        with pytest.raises(ValueError, match='obtem resultado eleicoes: argumento invalido'):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
             info = {
-            'Endor':   {'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 3, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},}
+                'Endor':   {'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 3,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}}, }
             target.obtem_resultado_eleicoes(info)
 
-    # os dicionarios de entrada das funções não devem ser alterados
+    # Verificar que o programa gera Value Error no caso de argumentos não válidos
+    # LISTA DE TESTES:
+    #       -> Verificar se o argumento é do tipo DICT                                     (3)
+    #       -> Verificar se o argumento está vazio                                         (4)
+    #       -> Verificar se o dicionario dos votos está vazio                              (5)
+    #       -> Verificar os nomes das keys (VOTOS, DEPUTADOS)                              (6, 7)
+    #       -> Verificar se o valor de (DEPUTADOS, VOTOS) são do tipo correto (INT, DICT)  (8, 9)
+    #       -> Verificar se o valor de votos de cada partido é do tipo correto INT         (10)
+    #       -> Verificar se o valor de votos for negativo e valor de deputados for 0
+    #          ou inferior                                                                 (11, 12)
+    #       -> Verificar se existir um circulo eleitoral com 0 votos totais                (13)
+    #       -> Verificar se falta a key VOTOS ou a key DEPUTADOS                           (14, 15)
+    #       -> Verificar se a key correspondente aos numeros de votos é do tipo
+    #           correto STR                                                                   (16)
+
+    def test_obtem_resultado_eleicoes_raise_errors10(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            target.obtem_resultado_eleicoes('deez nuts')
+
+    def test_obtem_resultado_eleicoes_raise_errors11(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            target.obtem_resultado_eleicoes({})
+
+    def test_obtem_resultado_eleicoes_raise_errors12(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            info = {
+                'Endor':   {'deputados': 7,
+                            'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 6,
+                            'votos': {}},
+                'Tatooine': {'deputados': 3,
+                             'votos': {'A': 3000, 'B': 1900}}}
+            target.obtem_resultado_eleicoes(info)
+
+    def test_obtem_resultado_eleicoes_raise_errors13(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            info = {
+                'Endor':   {'deputados': 7,
+                            'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 6,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+                'Tatooine': {'deputados': 3,
+                             'xxx': {'A': 3000, 'B': 1900}}}
+            target.obtem_resultado_eleicoes(info)
+
+    def test_obtem_resultado_eleicoes_raise_errors14(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            info = {
+                'Endor':   {'deputados': 7,
+                            'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 6,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+                'Tatooine': {'xxx': 3,
+                             'votos': {'A': 3000, 'B': 1900}}}
+            target.obtem_resultado_eleicoes(info)
+
+    def test_obtem_resultado_eleicoes_raise_errors15(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            info = {
+                'Endor':   {'deputados': 7,
+                            'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 'zero',
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+                'Tatooine': {'deputados': 3,
+                             'votos': {'A': 3000, 'B': 1900}}}
+            target.obtem_resultado_eleicoes(info)
+
+    def test_obtem_resultado_eleicoes_raise_errors16(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            info = {
+                'Endor':   {'deputados': 7,
+                            'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 6,
+                            'votos': 'zero'},
+                'Tatooine': {'deputados': 3,
+                             'votos': {'A': 3000, 'B': 1900}}}
+            target.obtem_resultado_eleicoes(info)
+
+    def test_obtem_resultado_eleicoes_raise_errors17(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            info = {
+                'Endor':   {'deputados': 7,
+                            'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 6,
+                            'votos': {'A': 9000, 'B': 'zero', 'D': 1500, 'E': 5000}},
+                'Tatooine': {'deputados': 3,
+                             'votos': {'A': 3000, 'B': 1900}}}
+            target.obtem_resultado_eleicoes(info)
+
+    def test_obtem_resultado_eleicoes_raise_errors18(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            info = {
+                'Endor':   {'deputados': 7,
+                            'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 6,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+                'Tatooine': {'deputados': 3,
+                             'votos': {'A': -69, 'B': 1900}}}
+            target.obtem_resultado_eleicoes(info)
+
+    def test_obtem_resultado_eleicoes_raise_errors19(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            info = {
+                'Endor':   {'deputados': 0,
+                            'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 6,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+                'Tatooine': {'deputados': 3,
+                             'votos': {'A': 3000, 'B': 1900}}}
+            target.obtem_resultado_eleicoes(info)
+
+    def test_obtem_resultado_eleicoes_raise_errors20(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            info = {
+                'Endor':   {'deputados': 7,
+                            'votos': {'A': 0, 'B': 0, 'C': 0, 'D': 0}},
+                'Hoth':    {'deputados': 6,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+                'Tatooine': {'deputados': 3,
+                             'votos': {'A': 3000, 'B': 1900}}}
+            target.obtem_resultado_eleicoes(info)
+
+    def test_obtem_resultado_eleicoes_raise_errors21(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            info = {
+                'Endor':   {'deputados': 7},
+                'Hoth':    {'deputados': 6,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+                'Tatooine': {'deputados': 3,
+                             'votos': {'A': 3000, 'B': 1900}}}
+            target.obtem_resultado_eleicoes(info)
+
+    def test_obtem_resultado_eleicoes_raise_errors22(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            info = {
+                'Endor':   {'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 6,
+                            'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+                'Tatooine': {'deputados': 3,
+                             'votos': {'A': 3000, 'B': 1900}}}
+            target.obtem_resultado_eleicoes(info)
+
+    def test_obtem_resultado_eleicoes_raise_errors23(self):
+        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
+            info = {
+                'Endor':   {'deputados': 7,
+                            'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+                'Hoth':    {'deputados': 6,
+                            'votos': {69: 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+                'Tatooine': {'deputados': 3,
+                             'votos': {'A': 3000, 'B': 1900}}}
+            target.obtem_resultado_eleicoes(info)
+
+    #################################################################
+    # os dicionarios de entrada das funções não devem ser alterados #
+    #################################################################
+
     def test_calcula_quocientes_alteracao_diconarios(self):
         dicionario = {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}
         copia_dicionario = copy.deepcopy(dicionario)
 
-        target.calcula_quocientes({'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}, 7)
+        target.calcula_quocientes(
+            {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}, 7)
         assert dicionario == copia_dicionario
 
     def test_atribui_mandatos_alteracao_dicionarios(self):
@@ -256,211 +444,67 @@ class TestPublicMetodoHondt:
 
     def test_obtem_partidos_alteracao_dicionarios(self):
         dicionario = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
+            'Endor':   {'deputados': 7,
+                        'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+            'Hoth':    {'deputados': 6,
+                        'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+            'Tatooine': {'deputados': 3,
+                         'votos': {'A': 3000, 'B': 1900}}}
         copia_dicionario = copy.deepcopy(dicionario)
 
         target.obtem_partidos(dicionario)
         assert dicionario == copia_dicionario
 
-    def test_obtem_resultado_eleicoes_dicionarios(self):
+    def test_obtem_resultado_eleicoes_alteracao_dicionarios(self):
         dicionario = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
+            'Endor':   {'deputados': 7,
+                        'votos': {'A': 12000, 'B': 7500, 'C': 5250, 'D': 3000}},
+            'Hoth':    {'deputados': 6,
+                        'votos': {'A': 9000, 'B': 11500, 'D': 1500, 'E': 5000}},
+            'Tatooine': {'deputados': 3,
+                         'votos': {'A': 3000, 'B': 1900}}}
         copia_dicionario = copy.deepcopy(dicionario)
 
         target.obtem_resultado_eleicoes(dicionario)
         assert dicionario == copia_dicionario
 
-        
-    def test_obtem_resultado_eleicoes2(self):
-        info = {
-            'Endor':   {'deputados': 12,
-                        'votos': {'A':117542, 'B':79123, 'C':47887, 'D':28991}},
-            'Hoth':    {'deputados': 4,
-                        'votos': {'B':47800, 'A':56000, 'E':12877, 'D':28000}}}
-        ref = [('A', 7, 173542), ('B', 5, 126923), ('D', 2, 56991), ('C', 2, 47887), ('E', 0, 12877)]
-        
-        assert ref == target.obtem_resultado_eleicoes(info)
-
-    # Verificar que o programa gera Value Error no caso de argumentos não válidos
-    # LISTA DE TESTES:
-    #       -> Verificar se o argumento é do tipo DICT                                     (3)
-    #       -> Verificar se o argumento está vazio                                         (4)
-    #       -> Verificar se o dicionario dos votos está vazio                              (5)
-    #       -> Verificar os nomes das keys (VOTOS, DEPUTADOS)                              (6, 7)
-    #       -> Verificar se o valor de (DEPUTADOS, VOTOS) são do tipo correto (INT, DICT)  (8, 9)
-    #       -> Verificar se o valor de votos de cada partido é do tipo correto INT         (10)
-    #       -> Verificar se o valor de votos for negativo e valor de deputados for 0       
-    #          ou inferior                                                                 (11, 12)
-    #       -> Verificar se existir um circulo eleitoral com 0 votos totais                (13)
-    #       -> Verificar se falta a key VOTOS ou a key DEPUTADOS                           (14, 15)
-    #       -> Verificar se a key correspondente aos numeros de votos é do tipo
-    #           correto STR                                                                   (16)
-
-    def test_obtem_resultado_eleicoes3(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            target.obtem_resultado_eleicoes('deez nuts')
-    def test_obtem_resultado_eleicoes4(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            target.obtem_resultado_eleicoes({})
-    def test_obtem_resultado_eleicoes5(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
-            target.obtem_resultado_eleicoes(info)
-    def test_obtem_resultado_eleicoes6(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'xxx': {'A':3000, 'B':1900}}}
-            target.obtem_resultado_eleicoes(info)
-    def test_obtem_resultado_eleicoes7(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'xxx': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
-            target.obtem_resultado_eleicoes(info)
-    def test_obtem_resultado_eleicoes8(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 'zero', 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
-            target.obtem_resultado_eleicoes(info)
-    def test_obtem_resultado_eleicoes9(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': 'zero'},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
-            target.obtem_resultado_eleicoes(info)
-    def test_obtem_resultado_eleicoes10(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {'A':9000, 'B':'zero', 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
-            target.obtem_resultado_eleicoes(info)
-    def test_obtem_resultado_eleicoes11(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':-69, 'B':1900}}}
-            target.obtem_resultado_eleicoes(info)
-    def test_obtem_resultado_eleicoes12(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            info = {
-            'Endor':   {'deputados': 0, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
-            target.obtem_resultado_eleicoes(info)
-    def test_obtem_resultado_eleicoes13(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':0, 'B':0, 'C':0, 'D':0}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
-            target.obtem_resultado_eleicoes(info)
-    def test_obtem_resultado_eleicoes14(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            info = {
-            'Endor':   {'deputados': 7}, 
-            'Hoth':    {'deputados': 6, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
-            target.obtem_resultado_eleicoes(info)
-    def test_obtem_resultado_eleicoes15(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            info = {
-            'Endor':   {'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {'A':9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
-            target.obtem_resultado_eleicoes(info)
-    def test_obtem_resultado_eleicoes16(self):
-        with pytest.raises(ValueError, match='obtem_resultado_eleicoes: argumento invalido'):
-            info = {
-            'Endor':   {'deputados': 7, 
-                        'votos': {'A':12000, 'B':7500, 'C':5250, 'D':3000}},
-            'Hoth':    {'deputados': 6, 
-                        'votos': {69:9000, 'B':11500, 'D':1500, 'E':5000}},
-            'Tatooine': {'deputados': 3, 
-                        'votos': {'A':3000, 'B':1900}}}
-            target.obtem_resultado_eleicoes(info)
 
 
 class TestPublicSistemasLineares:
 
-   def test_produto_interno1(self):
-       assert target.produto_interno((1,2,3,4,5),(-4,5,-6,7,-8)) == -24.0
+    def test_produto_interno1(self):
+        assert target.produto_interno(
+            (1, 2, 3, 4, 5), (-4, 5, -6, 7, -8)) == -24.0
 
-   def test_verifica_convergencia1(self):
-       assert target.verifica_convergencia(((1, -0.5), (-1, 2)), (-0.4, 1.9), (0.1001, 1), 0.00001) == False
+    def test_verifica_convergencia1(self):
+        assert target.verifica_convergencia(
+            ((1, -0.5), (-1, 2)), (-0.4, 1.9), (0.1001, 1), 0.00001) == False
 
-   def test_verifica_convergencia2(self):
-       assert target.verifica_convergencia(((1, -0.5), (-1, 2)), (-0.4, 1.9), (0.1001, 1), 0.001) == True
+    def test_verifica_convergencia2(self):
+        assert target.verifica_convergencia(
+            ((1, -0.5), (-1, 2)), (-0.4, 1.9), (0.1001, 1), 0.001) == True
 
-   def test_retira_zeros_diagonal1(self):
-       assert target.retira_zeros_diagonal(((0, 1, 1), (1, 0, 0), (0, 1, 0)), (1, 2, 3)) == (((1, 0, 0), (0, 1, 0), (0, 1, 1)), (2, 3, 1))
+    def test_retira_zeros_diagonal1(self):
+        assert target.retira_zeros_diagonal(((0, 1, 1), (1, 0, 0), (0, 1, 0)), (1, 2, 3)) == (
+            ((1, 0, 0), (0, 1, 0), (0, 1, 1)), (2, 3, 1))
 
-   def test_eh_diagonal_dominante1(self):
-       assert target.eh_diagonal_dominante(((1, 2, 3, 4, 5),(4, -5, 6, -7, 8), (1, 3, 5, 3, 1), (-1, 0, -1, 0, -1), (0, 2, 4, 6, 8))) == False
+    def test_eh_diagonal_dominante1(self):
+        assert target.eh_diagonal_dominante(
+            ((1, 2, 3, 4, 5), (4, -5, 6, -7, 8), (1, 3, 5, 3, 1), (-1, 0, -1, 0, -1), (0, 2, 4, 6, 8))) == False
 
-   def test_eh_diagonal_dominante2(self):
-       assert target.eh_diagonal_dominante(((1, 0, 0), (0, 1, 0), (0, 1, 1))) == True
+    def test_eh_diagonal_dominante2(self):
+        assert target.eh_diagonal_dominante(
+            ((1, 0, 0), (0, 1, 0), (0, 1, 1))) == True
 
-   def test_resolve_sistema1(self):
-       def equal(x,y):
-           delta = 1e-10
-           return all(abs(x[i]-y[i])<delta for i in range(len(x)))
+    def test_resolve_sistema1(self):
+        def equal(x, y):
+            delta = 1e-10
+            return all(abs(x[i]-y[i]) < delta for i in range(len(x)))
 
-       A4, c4 = ((2, -1, -1), (2, -9, 7), (-2, 5, -9)), (-8, 8, -6)
-       ref = (-4.0, -1.0, 1.0)
+        A4, c4 = ((2, -1, -1), (2, -9, 7), (-2, 5, -9)), (-8, 8, -6)
+        ref = (-4.0, -1.0, 1.0)
 
-       assert equal(target.resolve_sistema(A4, c4, 1e-20), ref)
+        assert equal(target.resolve_sistema(A4, c4, 1e-20), ref)
 
 
 #######################################################
@@ -505,6 +549,7 @@ def is_under_git_control():
     except:
         return False
     return False
+
 
 def check_for_updates():
     if is_under_git_control():


### PR DESCRIPTION
Fixed ValueError message in test_obtem_resultado_eleicoes_raise_errors 1 to 9
Added test_limpa_texto4 and 5

Renamed all the fuctions that checked raised errors to end with "error" 
and renamed classes starting with TestPublic to start with Test
to improve readability in the tests outputs as they were too cluttered