### PR TITLE
[FP 2022/2023 P1] Add test_produto_interno_type test

### DIFF
--- a/fp/2022-2023/fp-p1/proj_tester.py
+++ b/fp/2022-2023/fp-p1/proj_tester.py
@@ -476,6 +476,10 @@ class TestSistemasLineares:
         assert target.produto_interno(
             (1, 2, 3, 4, 5), (-4, 5, -6, 7, -8)) == -24.0
 
+    def test_produto_interno_type(self):
+        assert isinstance(target.produto_interno(
+            (1, 2, 3, 4, 5), (-4, 5, -6, 7, -8)), float)
+            
     def test_verifica_convergencia1(self):
         assert target.verifica_convergencia(
             ((1, -0.5), (-1, 2)), (-0.4, 1.9), (0.1001, 1), 0.00001) == False


### PR DESCRIPTION
Os testes atuais comparam o resultado da função com uma _float_, no entanto isto não conta com a possibilidade dos valores retornados pela função serem do tipo _int_. Os testes privados exigem que este output seja do tipo _float_. Como tal, proponho este teste adicional, que permite verificar o tipo do output independentemente da sua validade matemática.

Big ups @SrGesus por me ter alertado para esta particularidade dos testes privados.